### PR TITLE
Feature/add dynamic dispatch for mixins

### DIFF
--- a/meross_iot/controller/device.py
+++ b/meross_iot/controller/device.py
@@ -317,12 +317,11 @@ class BaseDevice(object):
         basic_info = f"{self.name} ({self.type}, HW {self.hardware_version}, FW {self.firmware_version}, class: {self.__class__.__name__})"
         return basic_info
 
-    @staticmethod
-    def _parse_channels(channel_data: List) -> List[ChannelInfo]:
+    def _parse_channels(self,channel_data: List) -> List[ChannelInfo]:
         res = []
         if channel_data is None:
             return res
-
+        
         for i, val in enumerate(channel_data):
             name = val.get('devName', 'Main channel')
             type = val.get('type')

--- a/meross_iot/controller/mixins/consumption.py
+++ b/meross_iot/controller/mixins/consumption.py
@@ -3,14 +3,14 @@ from datetime import datetime
 from typing import List, Optional
 
 from meross_iot.model.enums import Namespace
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 
 _LOGGER = logging.getLogger(__name__)
 
 
 _DATE_FORMAT = '%Y-%m-%d'
 
-
-class ConsumptionXMixin(object):
+class ConsumptionMixin(DynamicFilteringMixin):
     _execute_command: callable
 
     def __init__(self, device_uuid: str,
@@ -18,41 +18,10 @@ class ConsumptionXMixin(object):
                  **kwargs):
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
 
-    async def async_get_daily_power_consumption(self,
-                                                channel=0,
-                                                timeout: Optional[float] = None,
-                                                *args, **kwargs) -> List[dict]:
-        """
-        Returns the power consumption registered by this device.
-
-        :param channel: channel to read data from
-
-        :return: the historical consumption data
-        """
-        # TODO: returning a nice PowerConsumtpionReport object rather than a list of dict?
-        result = await self._execute_command(method="GET",
-                                             namespace=Namespace.CONTROL_CONSUMPTIONX,
-                                             payload={'channel': channel},
-                                             timeout=timeout)
-        data = result.get('consumptionx')
-
-        # Parse the json data into nice-python native objects
-        res = [{
-                'date': datetime.strptime(x.get('date'), _DATE_FORMAT),
-                'total_consumption_kwh': float(x.get('value'))/1000
-        } for x in data]
-
-        return res
-
-
-class ConsumptionMixin(object):
-    _execute_command: callable
-
-    def __init__(self, device_uuid: str,
-                 manager,
-                 **kwargs):
-        super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
-
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_CONSUMPTION.value
+    
     async def async_get_daily_power_consumption(self,
                                                 channel=0,
                                                 timeout: Optional[float] = None,
@@ -70,6 +39,44 @@ class ConsumptionMixin(object):
                                              payload={'channel': channel},
                                              timeout=timeout)
         data = result.get('consumption')
+
+        # Parse the json data into nice-python native objects
+        res = [{
+                'date': datetime.strptime(x.get('date'), _DATE_FORMAT),
+                'total_consumption_kwh': float(x.get('value'))/1000
+        } for x in data]
+
+        return res
+    
+class ConsumptionXMixin(ConsumptionMixin):
+    _execute_command: callable
+
+    def __init__(self, device_uuid: str,
+                 manager,
+                 **kwargs):
+        super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
+
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_CONSUMPTIONX.value
+    
+    async def async_get_daily_power_consumption(self,
+                                                channel=0,
+                                                timeout: Optional[float] = None,
+                                                *args, **kwargs) -> List[dict]:
+        """
+        Returns the power consumption registered by this device.
+
+        :param channel: channel to read data from
+
+        :return: the historical consumption data
+        """
+        # TODO: returning a nice PowerConsumtpionReport object rather than a list of dict?
+        result = await self._execute_command(method="GET",
+                                             namespace=Namespace.CONTROL_CONSUMPTIONX,
+                                             payload={'channel': channel},
+                                             timeout=timeout)
+        data = result.get('consumptionx')
 
         # Parse the json data into nice-python native objects
         res = [{

--- a/meross_iot/controller/mixins/diffuser_light.py
+++ b/meross_iot/controller/mixins/diffuser_light.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace, DiffuserLightMode
 from meross_iot.model.typing import RgbTuple
 from meross_iot.utilities.conversion import rgb_to_int, int_to_rgb
@@ -8,7 +9,7 @@ from meross_iot.utilities.conversion import rgb_to_int, int_to_rgb
 _LOGGER = logging.getLogger(__name__)
 
 
-class DiffuserLightMixin(object):
+class DiffuserLightMixin(DynamicFilteringMixin):
     _execute_command: callable
     check_full_update_done: callable
 
@@ -19,7 +20,11 @@ class DiffuserLightMixin(object):
 
         # Dictionary keeping the status for every channel
         self._channel_diffuser_light_status = {}
-
+    
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.DIFFUSER_LIGHT.value
+    
     async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
         locally_handled = False
 

--- a/meross_iot/controller/mixins/diffuser_spray.py
+++ b/meross_iot/controller/mixins/diffuser_spray.py
@@ -1,13 +1,14 @@
 import logging
 from typing import Optional
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace, DiffuserSprayMode
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DiffuserSprayMixin(object):
+class DiffuserSprayMixin(DynamicFilteringMixin):
     _execute_command: callable
     check_full_update_done: callable
 
@@ -19,6 +20,10 @@ class DiffuserSprayMixin(object):
         # Dictionary keeping the status for every channel
         self._channel_diffuser_spray_status = {}
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.DIFFUSER_SPRAY.value
+    
     async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
         locally_handled = False
 

--- a/meross_iot/controller/mixins/dnd.py
+++ b/meross_iot/controller/mixins/dnd.py
@@ -1,15 +1,19 @@
 import logging
 from typing import Optional, Dict
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace, RollerShutterState, DNDMode
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class SystemDndMixin:
+class SystemDndMixin(DynamicFilteringMixin):
     _execute_command: callable
     check_full_update_done: callable
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.SYSTEM_DND_MODE.value
     ## It looks like the DND mode update/change does not trigger any PUSH notification update.
     ## This means we won't catch any "DND mode change" via push notifications.
 

--- a/meross_iot/controller/mixins/electricity.py
+++ b/meross_iot/controller/mixins/electricity.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace
 from meross_iot.model.plugin.power import PowerInfo
 
@@ -11,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 _DATE_FORMAT = '%Y-%m-%d'
 
 
-class ElectricityMixin(object):
+class ElectricityMixin(DynamicFilteringMixin):
     _execute_command: callable
 
     def __init__(self, device_uuid: str,
@@ -21,7 +22,11 @@ class ElectricityMixin(object):
 
         # We'll hold a dictionary of lastest samples, one per channel
         self.__channel_cached_samples = {}
-
+    
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_ELECTRICITY.value
+    
     async def async_get_instant_metrics(self,
                                         channel=0,
                                         timeout: Optional[float] = None,

--- a/meross_iot/controller/mixins/encryption.py
+++ b/meross_iot/controller/mixins/encryption.py
@@ -4,7 +4,7 @@ import base64
 from Cryptodome.Cipher import AES
 from enum import Enum
 from typing import Dict
-
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace
 
 _LOGGER = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ class EncryptionAlg(Enum):
     ECDHE256 = 0
 
 
-class EncryptionSuiteMixin(object):
+class EncryptionSuiteMixin(DynamicFilteringMixin):
     _execute_command: callable
     _DEFAULT_IV="0000000000000000".encode("utf8")
     _abilities: Dict[str, dict]
@@ -29,7 +29,11 @@ class EncryptionSuiteMixin(object):
             self._encryption_alg = EncryptionAlg.ECDHE256
         else:
             raise ValueError("Unsupported/undetected encryption method")
-
+        
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.SYSTEM_ENCRYPTION.value
+    
     def _pad_to_16_bytes(self, data):
         block_size = 16
         pad_length = block_size - (len(data) % block_size)

--- a/meross_iot/controller/mixins/garage.py
+++ b/meross_iot/controller/mixins/garage.py
@@ -1,13 +1,14 @@
 import logging
 from typing import Optional, List
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.controller.device import ChannelInfo
 from meross_iot.model.enums import Namespace
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class GarageOpenerMixin:
+class GarageOpenerMixin(DynamicFilteringMixin):
     _channels: List[ChannelInfo]
     _execute_command: callable
     check_full_update_done: callable
@@ -24,7 +25,11 @@ class GarageOpenerMixin:
         for c in self._channels:
             self._door_open_state_by_channel[c.index] = None
             self._door_config_state_by_channel[c.index] = None
-
+    
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.GARAGE_DOOR_STATE.value
+    
     async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
         locally_handled = False
 

--- a/meross_iot/controller/mixins/hub.py
+++ b/meross_iot/controller/mixins/hub.py
@@ -1,18 +1,23 @@
 import logging
 from typing import Optional
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class HubMixn(object):
+class HubMixn(DynamicFilteringMixin):
     __PUSH_MAP = {
         Namespace.HUB_ONLINE: 'online',
         Namespace.HUB_TOGGLEX: 'togglex',
         Namespace.HUB_BATTERY: 'battery'
     }
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.HUB_ONLINE.value or device_ability == Namespace.HUB_TOGGLEX.value
+    
     def __init__(self, device_uuid: str,
                  manager,
                  **kwargs):
@@ -51,7 +56,7 @@ class HubMixn(object):
         return locally_handled or parent_handled
 
 
-class HubMs100Mixin(object):
+class HubMs100Mixin(DynamicFilteringMixin):
     __PUSH_MAP = {
         # TODO: check this
         Namespace.HUB_SENSOR_ALERT: 'alert',
@@ -66,7 +71,11 @@ class HubMs100Mixin(object):
                  manager,
                  **kwargs):
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
-
+    
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.HUB_SENSOR_ALL.value or device_ability == Namespace.HUB_SENSOR_ALERT.value or device_ability == Namespace.HUB_SENSOR_TEMPHUM.value
+    
     async def async_update(self, timeout: Optional[float] = None, *args, **kwargs) -> None:
         # Call the super implementation
         await super().async_update(*args, **kwargs)
@@ -119,7 +128,7 @@ class HubMs100Mixin(object):
         return locally_handled or parent_handled
 
 
-class HubMts100Mixin(object):
+class HubMts100Mixin(DynamicFilteringMixin):
     __PUSH_MAP = {
         Namespace.HUB_MTS100_ALL: 'all',
         Namespace.HUB_MTS100_MODE: 'mode',
@@ -133,7 +142,11 @@ class HubMts100Mixin(object):
                  manager,
                  **kwargs):
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
-
+    
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.HUB_MTS100_ALL.value or device_ability == Namespace.HUB_MTS100_MODE.value or device_ability == Namespace.HUB_MTS100_TEMPERATURE.value
+    
     async def async_update(self, timeout: Optional[float] = None, *args, **kwargs) -> None:
         try:
             # Call the super implementation

--- a/meross_iot/controller/mixins/light.py
+++ b/meross_iot/controller/mixins/light.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, Union
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.controller.mixins.toggle import ToggleMixin, ToggleXMixin
 from meross_iot.model.enums import Namespace, LightMode
 from meross_iot.model.plugin.light import LightInfo
@@ -10,7 +11,7 @@ from meross_iot.utilities.conversion import rgb_to_int
 _LOGGER = logging.getLogger(__name__)
 
 
-class LightMixin(object):
+class LightMixin(DynamicFilteringMixin):
     """
     Mixin class that enables light control.
     """
@@ -27,6 +28,10 @@ class LightMixin(object):
         # Dictionary keeping the status for every channel
         self._channel_light_status = {}
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_LIGHT.value
+    
     async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
         locally_handled = False
 

--- a/meross_iot/controller/mixins/roller_shutter.py
+++ b/meross_iot/controller/mixins/roller_shutter.py
@@ -1,12 +1,13 @@
 import logging
 from typing import Optional, Dict
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace, RollerShutterState
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class RollerShutterTimerMixin:
+class RollerShutterTimerMixin(DynamicFilteringMixin):
     _execute_command: callable
     check_full_update_done: callable
     uuid: str
@@ -22,6 +23,10 @@ class RollerShutterTimerMixin:
         self._shutter__position_by_channel = {}
         self._shutter__config_by_channel = {}
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.ROLLER_SHUTTER_STATE.value
+    
     async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
         locally_handled = False
 

--- a/meross_iot/controller/mixins/runtime.py
+++ b/meross_iot/controller/mixins/runtime.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace
 
 _LOGGER = logging.getLogger(__name__)
@@ -9,7 +10,7 @@ _LOGGER = logging.getLogger(__name__)
 _DATE_FORMAT = '%Y-%m-%d'
 
 
-class SystemRuntimeMixin(object):
+class SystemRuntimeMixin(DynamicFilteringMixin):
     _execute_command: callable
 
     def __init__(self, device_uuid: str,
@@ -18,6 +19,10 @@ class SystemRuntimeMixin(object):
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
         self._runtime_info = {}
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.SYSTEM_RUNTIME.value
+    
     async def async_update_runtime_info(self, timeout: Optional[float] = None, *args, **kwargs) -> dict:
         """
         Polls the device to gather the latest runtime information for this device.

--- a/meross_iot/controller/mixins/spray.py
+++ b/meross_iot/controller/mixins/spray.py
@@ -1,12 +1,13 @@
 import logging
 from typing import Optional
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace, SprayMode
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class SprayMixin(object):
+class SprayMixin(DynamicFilteringMixin):
     _execute_command: callable
     check_full_update_done: callable
     #async_handle_update: Callable[[Namespace, dict], Awaitable]
@@ -19,6 +20,10 @@ class SprayMixin(object):
         # Dictionary keeping the status for every channel
         self._channel_spray_status = {}
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_SPRAY.value
+    
     async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
         locally_handled = False
 

--- a/meross_iot/controller/mixins/system.py
+++ b/meross_iot/controller/mixins/system.py
@@ -1,12 +1,13 @@
 import logging
 from typing import Optional
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.model.enums import Namespace, OnlineStatus
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class SystemAllMixin(object):
+class SystemAllMixin(DynamicFilteringMixin):
     _execute_command: callable
     #async_handle_update: Callable[[Namespace, dict], Awaitable]
 
@@ -14,7 +15,10 @@ class SystemAllMixin(object):
                  manager,
                  **kwargs):
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
-
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.SYSTEM_ALL.value
+    
     async def async_update(self, timeout: Optional[float] = None, *args, **kwargs) -> None:
         # Call the super implementation
         await super().async_update(timeout=timeout, *args, **kwargs)
@@ -28,7 +32,7 @@ class SystemAllMixin(object):
         await self.async_handle_update(namespace=Namespace.SYSTEM_ALL, data=result)
 
 
-class SystemOnlineMixin(object):
+class SystemOnlineMixin(DynamicFilteringMixin):
     _online: OnlineStatus
     #async_handle_update: Callable[[Namespace, dict], Awaitable]
 
@@ -37,6 +41,10 @@ class SystemOnlineMixin(object):
                  **kwargs):
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.SYSTEM_ONLINE.value
+    
     async def async_handle_update(self, namespace: Namespace, data: dict) -> bool:
         _LOGGER.debug(f"Handling {self.__class__.__name__} mixin data update.")
         locally_handled = False

--- a/meross_iot/controller/mixins/thermostat.py
+++ b/meross_iot/controller/mixins/thermostat.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, List, Dict
 
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 from meross_iot.controller.device import ChannelInfo
 from meross_iot.model.enums import Namespace, ThermostatMode, ThermostatWorkingMode, ThermostatModeBState
 
@@ -130,7 +131,7 @@ class ThermostatState:
         return float(temp)/10.0
 
 
-class ThermostatModeMixin:
+class ThermostatModeMixin(DynamicFilteringMixin):
     _execute_command: callable
     check_full_update_done: callable
     _thermostat_state_by_channel: Dict[int, ThermostatState]
@@ -141,6 +142,10 @@ class ThermostatModeMixin:
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
         self._thermostat_state_by_channel = {}
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_THERMOSTAT_MODE.value
+    
     def _update_mode(self, mode_data: Dict):
         # The MTS200 thermostat does bring a object for every sensor/channel it handles.
         for c in mode_data:
@@ -259,7 +264,7 @@ class ThermostatModeMixin:
         mode_data = result.get('mode')
         self._update_mode(mode_data)
 
-class ThermostatModeBMixin:
+class ThermostatModeBMixin(DynamicFilteringMixin):
     _execute_command: callable
     check_full_update_done: callable
     _thermostat_state_by_channel: Dict[int, ThermostatState]
@@ -270,6 +275,10 @@ class ThermostatModeBMixin:
         super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
         self._thermostat_state_by_channel = {}
 
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_THERMOSTAT_MODEB.value
+    
     def _update_mode(self, mode_data: Dict):
         # The MTS200 thermostat does bring a object for every sensor/channel it handles.
         for c in mode_data:

--- a/meross_iot/controller/mixins/toggle.py
+++ b/meross_iot/controller/mixins/toggle.py
@@ -2,11 +2,83 @@ import logging
 from typing import Optional
 
 from meross_iot.model.enums import Namespace
-
+from meross_iot.controller.mixins.utilities import DynamicFilteringMixin
 _LOGGER = logging.getLogger(__name__)
 
+class ToggleMixin(DynamicFilteringMixin):
+    _execute_command: callable
+    #async_handle_update: Callable[[Namespace, dict], Awaitable]
 
-class ToggleXMixin(object):
+    def __init__(self, device_uuid: str,
+                 manager,
+                 **kwargs):
+        super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
+
+        # _channel_status is a dictionary keeping the status for every channel
+        self._channel_toggle_status = {}
+    
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return device_ability == Namespace.CONTROL_TOGGLE.value
+    
+    async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
+        locally_handled = False
+
+        if namespace == Namespace.CONTROL_TOGGLE:
+            _LOGGER.debug(f"ToggleMixin handling push notification for namespace {namespace}")
+            payload = data.get('toggle')
+            if payload is None:
+                _LOGGER.error(f"ToggleMixin could not find 'toggle' attribute in push notification data: {data}")
+            else:
+                channel_index = payload.get('channel', 0)
+                switch_state = payload['onoff'] == 1
+                self._channel_toggle_status[channel_index] = switch_state
+                locally_handled = True
+
+        # Always call the parent handler when done with local specific logic. This gives the opportunity to all
+        # ancestors to catch all events.
+        parent_handled = await super().async_handle_push_notification(namespace=namespace, data=data)
+        return locally_handled or parent_handled
+
+    async def async_handle_update(self, namespace: Namespace, data: dict) -> bool:
+        _LOGGER.debug(f"Handling {self.__class__.__name__} mixin data update.")
+        locally_handled = False
+        if namespace == Namespace.SYSTEM_ALL:
+            payload = data.get('all', {}).get('control', {}).get('toggle', {})
+            channel_index = payload.get('channel', 0)
+            switch_state = payload['onoff'] == 1
+            self._channel_toggle_status[channel_index] = switch_state
+            locally_handled = True
+        super_handled = await super().async_handle_update(namespace=namespace, data=data)
+        return super_handled or locally_handled
+
+    def is_on(self, channel=0, *args, **kwargs) -> Optional[bool]:
+        self.check_full_update_done()
+        return self._channel_toggle_status.get(channel, None)
+
+    async def async_turn_off(self, channel=0, timeout: Optional[float] = None, *args, **kwargs) -> None:
+        await self._execute_command(method="SET",
+                                    namespace=Namespace.CONTROL_TOGGLE,
+                                    payload={'toggle': {"onoff": 0, "channel": channel}},
+                                    timeout=timeout)
+        # Assume the command was ok, so immediately update the internal state
+        self._channel_toggle_status[channel] = False
+
+    async def async_turn_on(self, channel=0, timeout: Optional[float] = None, *args, **kwargs) -> None:
+        await self._execute_command(method="SET",
+                                    namespace=Namespace.CONTROL_TOGGLE,
+                                    payload={'toggle': {"onoff": 1, "channel": channel}},
+                                    timeout=timeout)
+        # Assume the command was ok, so immediately update the internal state
+        self._channel_toggle_status[channel] = True
+
+    async def async_toggle(self, channel=0, *args, **kwargs) -> None:
+        if self.is_on(channel=channel):
+            await self.async_turn_off(channel=channel)
+        else:
+            await self.async_turn_on(channel=channel)
+
+class ToggleXMixin(ToggleMixin):
     """
     This mixin is implemented by devices that support ToggleX operation, such as smart switches
     and smart bulbs.
@@ -22,7 +94,11 @@ class ToggleXMixin(object):
 
         # _channel_status is a dictionary keeping the status for every channel
         self._channel_togglex_status = {}
-
+    
+    @staticmethod
+    def filter(device_ability : str, device_name : str):
+        return device_ability == Namespace.CONTROL_TOGGLEX.value
+    
     async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
         locally_handled = False
 
@@ -117,76 +193,6 @@ class ToggleXMixin(object):
 
         :return: None
         """
-        if self.is_on(channel=channel):
-            await self.async_turn_off(channel=channel)
-        else:
-            await self.async_turn_on(channel=channel)
-
-
-class ToggleMixin(object):
-    _execute_command: callable
-    #async_handle_update: Callable[[Namespace, dict], Awaitable]
-
-    def __init__(self, device_uuid: str,
-                 manager,
-                 **kwargs):
-        super().__init__(device_uuid=device_uuid, manager=manager, **kwargs)
-
-        # _channel_status is a dictionary keeping the status for every channel
-        self._channel_toggle_status = {}
-
-    async def async_handle_push_notification(self, namespace: Namespace, data: dict) -> bool:
-        locally_handled = False
-
-        if namespace == Namespace.CONTROL_TOGGLE:
-            _LOGGER.debug(f"ToggleMixin handling push notification for namespace {namespace}")
-            payload = data.get('toggle')
-            if payload is None:
-                _LOGGER.error(f"ToggleMixin could not find 'toggle' attribute in push notification data: {data}")
-            else:
-                channel_index = payload.get('channel', 0)
-                switch_state = payload['onoff'] == 1
-                self._channel_toggle_status[channel_index] = switch_state
-                locally_handled = True
-
-        # Always call the parent handler when done with local specific logic. This gives the opportunity to all
-        # ancestors to catch all events.
-        parent_handled = await super().async_handle_push_notification(namespace=namespace, data=data)
-        return locally_handled or parent_handled
-
-    async def async_handle_update(self, namespace: Namespace, data: dict) -> bool:
-        _LOGGER.debug(f"Handling {self.__class__.__name__} mixin data update.")
-        locally_handled = False
-        if namespace == Namespace.SYSTEM_ALL:
-            payload = data.get('all', {}).get('control', {}).get('toggle', {})
-            channel_index = payload.get('channel', 0)
-            switch_state = payload['onoff'] == 1
-            self._channel_toggle_status[channel_index] = switch_state
-            locally_handled = True
-        super_handled = await super().async_handle_update(namespace=namespace, data=data)
-        return super_handled or locally_handled
-
-    def is_on(self, channel=0, *args, **kwargs) -> Optional[bool]:
-        self.check_full_update_done()
-        return self._channel_toggle_status.get(channel, None)
-
-    async def async_turn_off(self, channel=0, timeout: Optional[float] = None, *args, **kwargs) -> None:
-        await self._execute_command(method="SET",
-                                    namespace=Namespace.CONTROL_TOGGLE,
-                                    payload={'toggle': {"onoff": 0, "channel": channel}},
-                                    timeout=timeout)
-        # Assume the command was ok, so immediately update the internal state
-        self._channel_toggle_status[channel] = False
-
-    async def async_turn_on(self, channel=0, timeout: Optional[float] = None, *args, **kwargs) -> None:
-        await self._execute_command(method="SET",
-                                    namespace=Namespace.CONTROL_TOGGLE,
-                                    payload={'toggle': {"onoff": 1, "channel": channel}},
-                                    timeout=timeout)
-        # Assume the command was ok, so immediately update the internal state
-        self._channel_toggle_status[channel] = True
-
-    async def async_toggle(self, channel=0, *args, **kwargs) -> None:
         if self.is_on(channel=channel):
             await self.async_turn_off(channel=channel)
         else:

--- a/meross_iot/controller/mixins/utilities.py
+++ b/meross_iot/controller/mixins/utilities.py
@@ -1,0 +1,26 @@
+from typing import List
+from meross_iot.controller.device import ChannelInfo
+
+class DynamicFilteringMixin(object):
+    # Filter device based on user-provided input. We presently match on the ability and name, but
+    # may provide additional parameters in kwargs.
+    # Returns true if filter matches, false if not
+    @staticmethod
+    def filter(device_ability : str, device_name : str,**kwargs):
+        return False
+# Some devices (e.g. BBSolar lights) use multiple channels to represent a single logical entity, but don't indicate 
+# that in the abilities. Therefore, we provide a special type of mixin, the "channelRemappingMixin", which will provide
+# the relevant channelInfo for us. 
+class ChannelRemappingMixin(DynamicFilteringMixin):
+    def remap(self,channelInfo : List[ChannelInfo]) -> List[ChannelInfo]:
+        return None
+    
+    # We rely on the MRO here, and override the _parse_channels function
+    # of the baseDevice
+    def _parse_channels(self,channel_data: List) -> List[ChannelInfo]:
+        res = super()._parse_channels(channel_data)
+        remapped = self.remap(res)
+        if remapped != None:
+            return remapped
+        # Fall-through, return original
+        return res

--- a/meross_iot/http_api.py
+++ b/meross_iot/http_api.py
@@ -448,7 +448,7 @@ class MerossHttpClient(object):
         """
         data = {
             "system":platform.system(),
-            "vendor": "meross" if not "bbsolar.cc" in url.lower() else "bbsolar",
+            "vendor": "meross" if not "bbsolar.cc" in creds.domain.lower() else "bbsolar",
             "uuid": log_identifier,
             "extra":"",
             "model":platform.machine(),

--- a/meross_iot/http_api.py
+++ b/meross_iot/http_api.py
@@ -103,7 +103,8 @@ class MerossHttpClient(object):
         Builds a MerossHttpClient using username/password combination.
         In any case, the login will generate a token, which might expire at any time.
 
-        :param api_base_url: Https base endpoint to use for API calls. It should be one of "https://iotx-eu.meross.com", "https://iotx-ap.meross.com" or "https://iotx-us.meross.com", based on your public IP region.,
+        :param api_base_url: Https base endpoint to use for API calls. It should be one of "https://iotx-eu.meross.com", "https://iotx-ap.meross.com" or "https://iotx-us.meross.com", based on your public IP region. For bbsolar devices, 
+        should be one of  "https://iotx-ap.bbsolar.cc" or "https://iotx-us.bbsolar.cc". 
         :param email: Meross account email
         :param password: Meross account password
         :param http_proxy: Optional http proxy to use when issuing the requests
@@ -305,10 +306,11 @@ class MerossHttpClient(object):
         m.update(datatosign.encode("utf8"))
         md5hash = m.hexdigest()
 
+        # Note: We subtly change the vendor header - required to support bbheader devices. 
         headers = {
             "AppVersion": app_version,
             "Authorization": "Basic" if cloud_creds is None else "Basic %s" % cloud_creds.token,
-            "vender": "meross",
+            "vendor": "meross" if not "bbsolar.cc" in url.lower() else "bbsolar",
             "AppType": app_type,
             "AppLanguage": "EN",
             "User-Agent": ua_header,
@@ -446,7 +448,7 @@ class MerossHttpClient(object):
         """
         data = {
             "system":platform.system(),
-            "vendor":"meross",
+            "vendor": "meross" if not "bbsolar.cc" in url.lower() else "bbsolar",
             "uuid": log_identifier,
             "extra":"",
             "model":platform.machine(),

--- a/tests/test_dynamic_dispatch.py
+++ b/tests/test_dynamic_dispatch.py
@@ -1,0 +1,123 @@
+import logging
+from multiprocessing import Process
+
+import socks
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from meross_iot import device_factory
+from meross_iot.controller.device import BaseDevice, HubDevice, GenericSubDevice
+from meross_iot.manager import MerossManager
+from meross_iot.model.enums import OnlineStatus, Namespace
+from tests import async_get_client
+import os
+from meross_iot.controller.mixins.consumption import ConsumptionXMixin, ConsumptionMixin
+from meross_iot.controller.mixins.diffuser_light import DiffuserLightMixin
+from meross_iot.controller.mixins.diffuser_spray import DiffuserSprayMixin
+from meross_iot.controller.mixins.dnd import SystemDndMixin
+from meross_iot.controller.mixins.electricity import ElectricityMixin
+from meross_iot.controller.mixins.encryption import EncryptionSuiteMixin
+from meross_iot.controller.mixins.garage import GarageOpenerMixin
+from meross_iot.controller.mixins.hub import HubMts100Mixin, HubMixn, HubMs100Mixin
+from meross_iot.controller.mixins.light import LightMixin
+from meross_iot.controller.mixins.roller_shutter import RollerShutterTimerMixin
+from meross_iot.controller.mixins.runtime import SystemRuntimeMixin
+from meross_iot.controller.mixins.spray import SprayMixin
+from meross_iot.controller.mixins.system import SystemAllMixin, SystemOnlineMixin
+from meross_iot.controller.mixins.thermostat import ThermostatModeMixin, ThermostatModeBMixin
+from meross_iot.controller.mixins.toggle import ToggleXMixin, ToggleMixin
+from meross_iot.controller.subdevice import Mts100v3Valve, Ms100Sensor
+from meross_iot.model.enums import Namespace
+from meross_iot.model.exception import UnknownDeviceType
+from meross_iot.model.http.device import HttpDeviceInfo
+from meross_iot.model.http.subdevice import HttpSubdeviceInfo
+
+# Note:you may have to add the parent directory to this test. 
+# On *NIX, run: export PYTHONPATH=$PYTHONPATH:$(pwd) from the parent directory
+# On windows, run: $env:PYTHONPATH = $pwd from the parent directory
+
+_LOGGER = logging.getLogger(__name__)
+
+if os.name == 'nt':
+    import asyncio
+
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+else:
+    import asyncio
+    
+_ABILITY_MATRIX = {
+    # Power plugs abilities
+    Namespace.CONTROL_TOGGLEX.value: ToggleXMixin,
+    Namespace.CONTROL_TOGGLE.value: ToggleMixin,
+    Namespace.CONTROL_CONSUMPTIONX.value: ConsumptionXMixin,
+    Namespace.CONTROL_CONSUMPTION.value: ConsumptionMixin,
+    Namespace.CONTROL_ELECTRICITY.value: ElectricityMixin,
+
+    # Encryption
+    Namespace.SYSTEM_ENCRYPTION.value: EncryptionSuiteMixin,
+
+    # Light abilities
+    Namespace.CONTROL_LIGHT.value: LightMixin,
+
+    # Garage opener
+    Namespace.GARAGE_DOOR_STATE.value: GarageOpenerMixin,
+
+    # Roller shutter timer
+    Namespace.ROLLER_SHUTTER_STATE.value: RollerShutterTimerMixin,
+
+    # Spray
+    Namespace.CONTROL_SPRAY.value: SprayMixin,
+
+    # Oil diffuser
+    Namespace.DIFFUSER_LIGHT.value: DiffuserLightMixin,
+    Namespace.DIFFUSER_SPRAY.value: DiffuserSprayMixin,
+
+    # System
+    Namespace.SYSTEM_ALL.value: SystemAllMixin,
+    Namespace.SYSTEM_ONLINE.value: SystemOnlineMixin,
+    Namespace.SYSTEM_RUNTIME.value: SystemRuntimeMixin,
+
+    # Hub
+    Namespace.HUB_ONLINE.value: HubMixn,
+    Namespace.HUB_TOGGLEX.value: HubMixn,
+
+    Namespace.HUB_SENSOR_ALL.value: HubMs100Mixin,
+    Namespace.HUB_SENSOR_ALERT.value: HubMs100Mixin,
+    Namespace.HUB_SENSOR_TEMPHUM.value: HubMs100Mixin,
+
+    Namespace.HUB_MTS100_ALL.value: HubMts100Mixin,
+    Namespace.HUB_MTS100_MODE.value: HubMts100Mixin,
+    Namespace.HUB_MTS100_TEMPERATURE.value: HubMts100Mixin,
+
+    # DND
+    Namespace.SYSTEM_DND_MODE.value: SystemDndMixin,
+
+    # Thermostat
+    Namespace.CONTROL_THERMOSTAT_MODE.value: ThermostatModeMixin,
+    Namespace.CONTROL_THERMOSTAT_MODEB.value: ThermostatModeBMixin,
+
+    # TODO: BIND, UNBIND, ONLINE, WIFI, ETC!
+}
+
+class TestDispatch():
+    def test_ability_matrix_mapping(self):
+        for ability, cls in _ABILITY_MATRIX.items():
+            dynamicCls = device_factory._dynamic_filter(ability,"xxx")
+            assert dynamicCls == cls
+    
+    def test_dynamic_mixin_creation(self):
+        # Create dynamic mixin
+        abilities = {'Appliance.Config.Key': {}, 'Appliance.Config.WifiList': {}, 'Appliance.Config.Wifi': {}, 'Appliance.Config.WifiX': {}, 'Appliance.Config.Trace': {}, 'Appliance.Config.Info': {}, 'Appliance.Config.OverTemp': {}, 
+                 'Appliance.Config.CustomTimer': {}, 'Appliance.Digest.CustomTimer': {}, 'Appliance.System.All': {}, 'Appliance.System.Hardware': {}, 'Appliance.System.Firmware': {}, 'Appliance.System.Debug': {}, 
+                 'Appliance.System.Online': {}, 'Appliance.System.Time': {}, 'Appliance.System.Clock': {}, 'Appliance.System.Ability': {}, 'Appliance.System.Runtime': {}, 'Appliance.System.Report': {}, 'Appliance.System.Position': {}, 
+                 'Appliance.Control.Multiple': {'maxCmdNum': 3}, 'Appliance.Control.Bind': {}, 'Appliance.Control.Unbind': {}, 'Appliance.Control.Upgrade': {}, 'Appliance.Control.OverTemp': {}, 
+                 'Appliance.Control.ToggleX': {}, 'Appliance.Control.Luminance': {}}
+        mixin = device_factory._build_cached_type("test",abilities,BaseDevice,"test")
+
+        for ability in abilities:
+            try:
+                abilityMatrixCls = _ABILITY_MATRIX[ability]
+                # We could use isinstance, but the assert messages look nicer this way
+                assert abilityMatrixCls in mixin.__bases__
+            except KeyError:
+                continue
+


### PR DESCRIPTION
The BBSolar Smart Plant Lights use multiple channels to represent a single "physical" light, which should be represented as a device. However, it doesn't expose any "unique" abilities to indicate that this is the case. 

The present approach to identifying mixin components (e.g. via abilities) doesn't facilitate this sort of identification. This MR migrates from using the ABILITY_MATRIX (within the device_factory) to a dynamic loading/dispatch facility. First, all mixins are loaded from the given package. Mixins are annotated with a special class: DynamicFilteringMixin, which exposes the "filter" function. When a new cached type is build, the filter function is run for each device ability/type. If it returns true, that mixin is assumed to be part of the device. 

Separation of the "extended" abilities is handled by class inheritance. For example, the ToggleMixin class represents the TOGGLE ability, and extends from DynamicFilteringMixin. The ToggleXMixin class extends from Toggle, and contains a unique filter function for TOGGLEX abilities. Some logic within the class loader prevents Toggle from being loaded if a subclass already is (e.g.toggleX).

Test cases have been added to the tests/test_dynamic_dispatch.py file. 